### PR TITLE
Add 3D acrylic preview using react-three-fiber

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
       "name": "acrylic-design",
       "version": "0.0.0",
       "dependencies": {
+        "@react-three/fiber": "^8.15.16",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "three": "^0.180.0"
       },
       "devDependencies": {
         "@types/react": "^18.3.2",
@@ -255,6 +257,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -952,6 +963,64 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@react-three/fiber": {
+      "version": "8.15.16",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.15.16.tgz",
+      "integrity": "sha512-4f47K9e2mP8W/guNtu3e2J/Nt6GwKTsX/YP2dktPZRcpHYEsqfXCO8kSfvVMb+lQ8wR0HoFzggqdnGuhZaui0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.1",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18.0",
+        "react-dom": ">=18.0",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1330,14 +1399,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1353,6 +1420,21 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1609,6 +1691,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.8.tgz",
@@ -1662,6 +1764,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/call-bind": {
@@ -1815,7 +1941,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2779,6 +2904,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3242,6 +3387,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/js-tokens": {
@@ -3784,6 +3950,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3792,6 +3983,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4291,6 +4497,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4635,6 +4856,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@react-three/fiber": "^8.15.16",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "three": "^0.180.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.2",

--- a/src/App.css
+++ b/src/App.css
@@ -26,7 +26,7 @@ p {
 
 .preview {
   position: relative;
-  min-height: 220px;
+  min-height: 260px;
   border-radius: 1.25rem;
   background: radial-gradient(circle at top, #bae6fd, #e0e7ff 55%, #c7d2fe 100%);
   display: grid;
@@ -34,21 +34,10 @@ p {
   overflow: hidden;
 }
 
-.preview-box {
-  width: clamp(120px, 20vw, 220px);
-  height: clamp(100px, 18vw, 200px);
-  border-radius: 1rem;
-  background: linear-gradient(145deg, rgba(96, 165, 250, 0.7), rgba(37, 99, 235, 0.9));
-  border: 1px solid rgba(255, 255, 255, 0.65);
-  box-shadow:
-    -20px 30px 60px rgba(15, 23, 42, 0.25),
-    inset 0 0 30px rgba(255, 255, 255, 0.45);
-  transform: rotateX(12deg) rotateY(-18deg);
-  transition: transform 0.4s ease;
-}
-
-.preview:hover .preview-box {
-  transform: rotateX(8deg) rotateY(-12deg) scale(1.02);
+.preview-canvas {
+  width: 100% !important;
+  height: 100% !important;
+  cursor: grab;
 }
 
 .preview-dimensions {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Canvas, useFrame } from '@react-three/fiber';
+import { BoxGeometry, EdgesGeometry } from 'three';
 import './App.css';
 
 const DEFAULT_DIMENSIONS = {
@@ -61,13 +63,28 @@ export default function App() {
         </header>
 
         <div className="preview" aria-hidden="true">
-          <div
-            className="preview-box"
-            style={{
-              transform: `rotateX(${12 + height / 500}deg) rotateY(${-18 + width / 600}deg)`
-                + ` scale(${1 + depth / 2000})`,
-            }}
-          />
+          <Canvas
+            className="preview-canvas"
+            shadows
+            camera={{ position: [5.5, 4.5, 6.25], fov: 40 }}
+          >
+            <color attach="background" args={[0xe2e8f0]} />
+            <ambientLight intensity={0.6} />
+            <directionalLight
+              position={[6, 8, 6]}
+              intensity={0.95}
+              castShadow
+              shadow-mapSize-width={2048}
+              shadow-mapSize-height={2048}
+            />
+            <spotLight
+              position={[-4, 6.5, -3]}
+              angle={0.6}
+              intensity={0.45}
+              penumbra={0.5}
+            />
+            <PreviewScene width={width} height={height} depth={depth} />
+          </Canvas>
           <div className="preview-dimensions">
             <span>W: {formatNumber(width)} mm</span>
             <span>H: {formatNumber(height)} mm</span>
@@ -129,5 +146,149 @@ export default function App() {
         </div>
       </section>
     </div>
+  );
+}
+
+const PREVIEW_SCALE = 0.01;
+const BASE_HEIGHT = 0.2;
+
+function PreviewScene({ width, height, depth }) {
+  const groupRef = useRef();
+  const scaled = useMemo(
+    () => ({
+      width: Math.max(width, 1) * PREVIEW_SCALE,
+      height: Math.max(height, 1) * PREVIEW_SCALE,
+      depth: Math.max(depth, 1) * PREVIEW_SCALE,
+    }),
+    [width, height, depth]
+  );
+
+  useFrame(({ clock }) => {
+    if (!groupRef.current) return;
+    const time = clock.getElapsedTime();
+    groupRef.current.rotation.y = 0.6 + Math.sin(time / 3) * 0.25;
+    groupRef.current.rotation.x = 0.25 + Math.sin(time / 4) * 0.06;
+  });
+
+  return (
+    <group ref={groupRef} position={[0, -0.4, 0]}>
+      <Base width={scaled.width} depth={scaled.depth} />
+      <AcrylicEnclosure dimensions={scaled} />
+      <MockFigure dimensions={scaled} />
+    </group>
+  );
+}
+
+function Base({ width, depth }) {
+  const baseWidth = width + 0.6;
+  const baseDepth = depth + 0.6;
+
+  return (
+    <mesh position={[0, BASE_HEIGHT / 2, 0]} receiveShadow castShadow>
+      <boxGeometry args={[baseWidth, BASE_HEIGHT, baseDepth]} />
+      <meshStandardMaterial color="#facc15" roughness={0.7} metalness={0.05} />
+    </mesh>
+  );
+}
+
+function AcrylicEnclosure({ dimensions }) {
+  const { width, height, depth } = dimensions;
+  const geometry = useMemo(
+    () => new BoxGeometry(width, height, depth),
+    [width, height, depth]
+  );
+  const edges = useMemo(() => new EdgesGeometry(geometry), [geometry]);
+
+  useEffect(
+    () => () => {
+      geometry.dispose();
+      edges.dispose();
+    },
+    [geometry, edges]
+  );
+
+  return (
+    <group position={[0, BASE_HEIGHT + height / 2, 0]}
+    >
+      <mesh geometry={geometry} castShadow>
+        <meshPhysicalMaterial
+          color="#60a5fa"
+          transparent
+          opacity={0.18}
+          roughness={0.2}
+          metalness={0.1}
+          clearcoat={0.9}
+          clearcoatRoughness={0.2}
+          transmission={0.95}
+          thickness={0.6}
+        />
+      </mesh>
+      <lineSegments geometry={edges}>
+        <lineBasicMaterial color="#2563eb" linewidth={1} />
+      </lineSegments>
+    </group>
+  );
+}
+
+function MockFigure({ dimensions }) {
+  const { height, width, depth } = dimensions;
+  const bodyHeight = height * 0.55;
+  const bodyRadius = Math.min(width, depth) * 0.23;
+  const headRadius = bodyRadius * 0.85;
+  const figureBaseY = BASE_HEIGHT;
+
+  return (
+    <group position={[0, figureBaseY, 0]}>
+      <mesh position={[0, bodyHeight / 2, 0]} castShadow>
+        <cylinderGeometry args={[bodyRadius * 0.9, bodyRadius * 1.05, bodyHeight, 36]} />
+        <meshStandardMaterial color="#7c3aed" roughness={0.35} metalness={0.2} />
+      </mesh>
+      <mesh position={[0, bodyHeight + headRadius, 0]} castShadow>
+        <sphereGeometry args={[headRadius, 32, 32]} />
+        <meshStandardMaterial color="#fca5a5" roughness={0.6} />
+      </mesh>
+      <mesh position={[0, bodyHeight + headRadius * 2.1, 0]} castShadow>
+        <coneGeometry args={[headRadius * 1.05, headRadius * 1.6, 6]} />
+        <meshStandardMaterial color="#ef4444" roughness={0.25} metalness={0.4} />
+      </mesh>
+      <MockFigureOrnaments
+        radius={headRadius * 0.45}
+        height={bodyHeight + headRadius * 2.7}
+      />
+      <mesh position={[0, 0.02, 0]} rotation={[0, 0, 0]} receiveShadow>
+        <cylinderGeometry args={[bodyRadius * 1.15, bodyRadius * 1.4, 0.04, 32]} />
+        <meshStandardMaterial color="#f97316" roughness={0.65} />
+      </mesh>
+    </group>
+  );
+}
+
+function MockFigureOrnaments({ radius, height }) {
+  const spherePositions = useMemo(
+    () => [
+      [radius, height, 0],
+      [-radius, height, 0],
+      [0, height, radius],
+      [0, height, -radius],
+      [0, height + radius * 0.75, 0],
+    ],
+    [radius, height]
+  );
+
+  const colors = ['#fbbf24', '#38bdf8', '#fb7185', '#22d3ee', '#a855f7'];
+
+  return (
+    <group>
+      {spherePositions.map((position, index) => (
+        <mesh key={index} position={position} castShadow>
+          <sphereGeometry args={[radius * 0.55, 24, 24]} />
+          <meshStandardMaterial
+            color={colors[index % colors.length]}
+            roughness={0.35}
+            metalness={0.3}
+          />
+        </mesh>
+      ))}
+    </group>
   );
 }


### PR DESCRIPTION
## Summary
- integrate react-three-fiber and three to render a 3D acrylic enclosure preview with responsive lighting and animation
- add a stylized mock figurine and base to visualize scale inside the configurable box
- adjust preview styling to host the real-time canvas

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82aab32fc832389c09782393ea5d7