### PR TITLE
Add dimension sliders and improve mobile layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,7 +26,7 @@ p {
 
 .preview {
   position: relative;
-  min-height: 260px;
+  min-height: clamp(240px, 45vw, 420px);
   border-radius: 1.25rem;
   background: radial-gradient(circle at top, #bae6fd, #e0e7ff 55%, #c7d2fe 100%);
   display: grid;
@@ -61,19 +61,49 @@ p {
 
 .form-grid {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
-.label {
+.dimension-field {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.1rem 1.25rem;
+  background: rgba(248, 250, 252, 0.75);
+  backdrop-filter: blur(10px);
   display: grid;
-  gap: 0.5rem;
-  text-align: left;
-  font-weight: 600;
-  color: #1e293b;
+  gap: 0.75rem;
+  min-width: 0;
+  margin: 0;
 }
 
-.label small {
+.dimension-field legend {
+  padding: 0;
+}
+
+.dimension-label {
+  margin: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  color: #1e293b;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.dimension-value {
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  color: #1d4ed8;
+  font-size: 0.95rem;
+}
+
+.dimension-input-row {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.dimension-input-row small {
   font-weight: 500;
   color: #64748b;
 }
@@ -91,6 +121,59 @@ input[type='number']:focus {
   border-color: #2563eb;
   box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.15);
   outline: none;
+}
+
+input[type='range'] {
+  width: 100%;
+  appearance: none;
+  height: 6px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #2563eb, #60a5fa);
+  position: relative;
+  cursor: pointer;
+}
+
+input[type='range']::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+input[type='range']::-moz-range-track {
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+input[type='range']::-webkit-slider-thumb {
+  appearance: none;
+  height: 20px;
+  width: 20px;
+  border-radius: 50%;
+  background: #1d4ed8;
+  border: 2px solid #bfdbfe;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+  transition: transform 0.2s ease;
+}
+
+input[type='range']::-moz-range-thumb {
+  height: 18px;
+  width: 18px;
+  border-radius: 50%;
+  background: #1d4ed8;
+  border: 2px solid #bfdbfe;
+  box-shadow: 0 4px 10px rgba(37, 99, 235, 0.35);
+  transition: transform 0.2s ease;
+}
+
+input[type='range']:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.2);
+}
+
+input[type='range']::-webkit-slider-thumb:hover,
+input[type='range']::-moz-range-thumb:hover {
+  transform: scale(1.05);
 }
 
 .summary {
@@ -136,10 +219,47 @@ input[type='number']:focus {
 
 @media (max-width: 600px) {
   body {
-    padding: 1.5rem 0;
+    padding: 1.25rem 0 2.5rem;
+    align-items: flex-start;
   }
 
   #root {
+    width: min(100%, 560px);
+    padding: 1.5rem 1.25rem 2.5rem;
+  }
+
+  .card {
     padding: 1.5rem;
+    border-radius: 1.25rem;
+    gap: 1.5rem;
+  }
+
+  .preview {
+    min-height: 260px;
+  }
+
+  .dimension-label {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .dimension-field {
+    padding: 1rem 1.1rem;
+  }
+}
+
+@media (max-width: 400px) {
+  .preview-dimensions {
+    bottom: 0.85rem;
+    gap: 0.4rem;
+  }
+
+  .preview-dimensions span {
+    padding: 0.3rem 0.6rem;
+  }
+
+  .dimension-field {
+    padding: 0.9rem 1rem;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,30 @@ const DEFAULT_DIMENSIONS = {
   depth: 12,
 };
 
+const DIMENSION_FIELDS = [
+  {
+    key: 'width',
+    label: 'Width',
+    helper: 'Left to right span',
+    min: 5,
+    max: 60,
+  },
+  {
+    key: 'height',
+    label: 'Height',
+    helper: 'Base to top',
+    min: 5,
+    max: 40,
+  },
+  {
+    key: 'depth',
+    label: 'Depth',
+    helper: 'Front to back',
+    min: 5,
+    max: 60,
+  },
+];
+
 const RATE_PER_CUBIC_CM = 0.08;
 const MIN_ORDER_TOTAL = 45;
 
@@ -40,12 +64,20 @@ export default function App() {
     [height]
   );
 
-  const handleChange = (key) => (event) => {
-    const nextValue = Number(event.target.value);
+  const setDimensionValue = (key, rawValue) => {
+    const nextValue = Number(rawValue);
     setDimensions((current) => ({
       ...current,
       [key]: Number.isFinite(nextValue) ? nextValue : 0,
     }));
+  };
+
+  const handleInputChange = (key) => (event) => {
+    setDimensionValue(key, event.target.value);
+  };
+
+  const handleSliderChange = (key) => (event) => {
+    setDimensionValue(key, event.target.value);
   };
 
   const isValid = width > 0 && height > 0 && depth > 0;
@@ -101,25 +133,46 @@ export default function App() {
         </div>
 
         <form className="form-grid" aria-label="Acrylic dimensions">
-          {[{ key: 'width', label: 'Width', helper: 'Left to right span' },
-            { key: 'height', label: 'Height', helper: 'Base to top' },
-            { key: 'depth', label: 'Depth', helper: 'Front to back' }].map(
-            ({ key, label, helper }) => (
-              <label key={key} className="label">
-                {label} (cm)
+          {DIMENSION_FIELDS.map(({ key, label, helper, min, max }) => {
+            const clampedValue = Math.min(Math.max(dimensions[key], min), max);
+            const sliderRange = Math.max(max - min, 0.0001);
+            const sliderProgress = ((clampedValue - min) / sliderRange) * 100;
+            const sliderGradient =
+              `linear-gradient(90deg, #2563eb 0%, #2563eb ${sliderProgress}%, ` +
+              `rgba(148, 163, 184, 0.35) ${sliderProgress}%, rgba(148, 163, 184, 0.35) 100%)`;
+
+            return (
+              <fieldset key={key} className="dimension-field">
+                <legend className="dimension-label">
+                  <span>{label} (cm)</span>
+                  <span className="dimension-value">{formatNumber(dimensions[key])}</span>
+                </legend>
                 <input
-                  type="number"
-                  min="0.1"
+                  type="range"
+                  min={min}
+                  max={max}
                   step="0.1"
-                  value={dimensions[key]}
-                  onChange={handleChange(key)}
-                  inputMode="numeric"
+                  value={clampedValue}
+                  onChange={handleSliderChange(key)}
                   aria-describedby={`${key}-helper`}
+                  style={{ background: sliderGradient }}
                 />
-                <small id={`${key}-helper`}>{helper}</small>
-              </label>
-            )
-          )}
+                <div className="dimension-input-row">
+                  <input
+                    type="number"
+                    min={min}
+                    max={max}
+                    step="0.1"
+                    value={dimensions[key]}
+                    onChange={handleInputChange(key)}
+                    inputMode="decimal"
+                    aria-describedby={`${key}-helper`}
+                  />
+                  <small id={`${key}-helper`}>{helper}</small>
+                </div>
+              </fieldset>
+            );
+          })}
         </form>
 
         <section className="summary" aria-live="polite">


### PR DESCRIPTION
## Summary
- add synchronized range sliders alongside numeric inputs for width, height, and depth
- restyle the dimension controls and preview area for better responsiveness and readability
- adjust mobile breakpoints and spacing to improve usability on small screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d82e97856483239e005e25dffdc52e